### PR TITLE
hides next event container if no next event exists

### DIFF
--- a/source/javascripts/meetup_event_embedder.js
+++ b/source/javascripts/meetup_event_embedder.js
@@ -15,12 +15,14 @@ define('meetup_event_embedder', [
     var self = this;
 
     self.template = $('#event-tmpl').html();
-    self.container = $('article.next-event-information');
+    self.root = $('.next-event-information');
+    self.container = self.root.find('article.next-event-information');
     self.meetup = new Meetup();
     self.meetup.events({
       success: function (data) {
         if (data && data.results && data.results.length > 0) {
           self.embed(data.results[0]);
+          self.container.addClass('loaded');
         }
       }
     });

--- a/source/stylesheets/index/_next-event.scss
+++ b/source/stylesheets/index/_next-event.scss
@@ -1,10 +1,13 @@
 .next-event {
   background: #fff;
-  @extend %slide-in-up;
+  display: none;
 
-  @include media($medium-screen) {
-    @include row(table);
-  };
+  &.loaded {
+    @extend %slide-in-up;
+    @include media($medium-screen) {
+      @include row(table);
+    }
+  }
 }
 
 .next-event-information {


### PR DESCRIPTION
This commit hides the empty white box that appears over the hero until the next event is fetched and embedded successfully. If there is no next event, this commit prevents an empty white box from appearing across the hero.
