### PR TITLE
feat: Add link to meetup page

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -5,6 +5,8 @@ title: Philly.rb
 <section class="hero">
   <div class="wrapper">
     <h1>Philly.rb is the one and only user group in Philadelphia dedicated to helping Ruby enthusiasts learn, network, and socialize.</h1>
+    <hr>
+    <h1>Check us out on <a href="https://www.meetup.com/phillyrb" target="_blank">Meetup</a> to join our next event</h1>
   </div>
 </section>
 


### PR DESCRIPTION
Displaying out next event information is broken and I can't get the site running locally (Ruby 2.3 😬 ) so I added a basic link in our hero section.

![Screenshot 2024-11-20 at 10 30 58](https://github.com/user-attachments/assets/3766a95e-3d4e-4ae1-90ee-6e62f20f2a29)

It's not pretty but it works for now. It's the same link as in our header just a little more front an center IMO.