### PR TITLE
Add GitHub Actions workflow to build site on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - run: bundle exec middleman build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           bundler-cache: true
 
-      - run: bundle exec middleman build
+      - run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           bundler-cache: true
 
-      - run: make build
+      - run: bundle exec middleman build


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build.yml` that runs `bundle exec middleman build` on every PR to `main` and on pushes to `main`.
- Uses `ruby/setup-ruby@v1` with `bundler-cache: true`, so Ruby version is picked up from `.ruby-version` (3.4.2) and gems are cached between runs.
- No Node setup needed — Ubuntu runners ship with Node, which is enough for the ExecJS-driven asset pipeline.

## Why
Right now every merge (especially Dependabot bumps like #68, #70–#72) relies on a human running the build locally to confirm nothing broke. A simple CI build catches regressions automatically and lets us trust Dependabot PRs at a glance.

## Test plan
- [ ] Workflow appears on this PR and finishes green
- [ ] Re-run on `main` after merge also goes green
- [ ] Confirm subsequent Dependabot PRs (e.g. #68) get a build check automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)